### PR TITLE
Reduce iNaturalist observation page size

### DIFF
--- a/index.html.html
+++ b/index.html.html
@@ -295,7 +295,7 @@
         
         async function fetchMushroomObservations(taxonId, excludeObservationId = null) {
             const requestedSpeciesInfo = mushroomSpecies.find(s => s.id === taxonId);
-            let apiUrl = `https://api.inaturalist.org/v1/observations?taxon_id=${taxonId}&iconic_taxa=Fungi&quality_grade=research&photos=true&photo_license=cc-by,cc-by-nc,cc-by-sa,cc-by-nc-sa,cc0&per_page=50&order_by=votes&locale=en`;
+            let apiUrl = `https://api.inaturalist.org/v1/observations?taxon_id=${taxonId}&iconic_taxa=Fungi&quality_grade=research&photos=true&photo_license=cc-by,cc-by-nc,cc-by-sa,cc-by-nc-sa,cc0&per_page=10&order_by=votes&locale=en&fields=id,photos,taxon,user,license_code`;
             if (excludeObservationId) {
                 apiUrl += `&not_id=${excludeObservationId}`;
             }


### PR DESCRIPTION
## Summary
- limit requests in `fetchMushroomObservations` to 10 results per page
- request only `id`, `photos`, `taxon`, `user`, and `license_code` fields

## Testing
- `node -e "fetch('https://api.inaturalist.org/v1/observations?per_page=1').then(res=>res.json()).then(data=>console.log('ok')).catch(err=>console.error('error',err));"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6848a79d5280832983c98bc7c08de964