### PR TITLE
Improve image quality and grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     .difficulty-button { background: #d4c8b8; color: #5d4e37; border: 1px solid #bcaea0; padding: 8px 16px; border-radius: 10px; cursor: pointer; margin: 0 6px; }
     .difficulty-button.active { background: #8b6f47; color: #fff8f0; border-color: transparent; }
 
-    .image-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; margin-bottom: 14px; }
+    .image-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; margin: 0 auto 14px; max-width: 740px; }
     .image-container { width: 100%; aspect-ratio: 1 / 1; background: #eee0cf; border-radius: 14px; overflow: hidden; border: 2px solid rgba(139, 90, 43, 0.25); position: relative; }
     .mushroom-image { width: 100%; height: 100%; object-fit: cover; display: block; }
     .photo-credit { position: absolute; left: 0; right: 0; bottom: 0; background: rgba(255, 248, 240, 0.75); font-size: .6rem; padding: 2px 4px; text-align: center; color: #5d4e37; }
@@ -60,8 +60,8 @@
     .secondary-action-button { background: #d4c8b8; color: #3d2914; border: 1px solid #bcaea0; padding: 10px 18px; border-radius: 999px; cursor: pointer; font-weight: 600; }
     .secondary-action-button:disabled { opacity: .55; cursor: not-allowed; }
 
-    .options { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; }
-    .option-button { background: rgba(255, 248, 240, 0.85); border: 2px solid rgba(139, 90, 43, 0.25); color: #5d4e37; padding: 16px; border-radius: 12px; cursor: pointer; font-weight: 600; text-align: center; }
+    .options { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; max-width: 740px; margin: 0 auto; }
+    .option-button { background: rgba(255, 248, 240, 0.85); border: 2px solid rgba(139, 90, 43, 0.25); color: #5d4e37; padding: 16px; border-radius: 12px; cursor: pointer; font-weight: 600; text-align: center; aspect-ratio: 1 / 1; display: flex; flex-direction: column; align-items: center; justify-content: center; }
     .option-button:hover:not(:disabled) { background: rgba(139, 90, 43, 0.15); border-color: rgba(139, 90, 43, 0.45); transform: translateY(-1px); }
     .option-button:disabled { opacity: .75; cursor: not-allowed; }
     .option-button.correct { background: rgba(76, 175, 80, 0.18); border-color: #4CAF50; color: #2e7d32; }
@@ -114,7 +114,7 @@
     <div class="game-screen">
       <div class="image-grid" id="imageGrid"></div>
       <div class="game-actions">
-        <button id="newPhotosBtn" class="secondary-action-button" style="display:none;">New Photos (1 use)</button>
+        <button id="newPhotosBtn" class="secondary-action-button" style="display:none;margin:10px auto 0;">New Photos (1 use)</button>
       </div>
       <div class="options" id="optionsContainer"></div>
     </div>
@@ -344,7 +344,7 @@
         per_page: '50',
         order: 'desc',
         order_by: 'votes',
-        fields: 'results.id,results.photos.id,results.photos.license_code,results.photos.url,results.photos.attribution,results.observed_on_details.date,results.taxon.id'
+        fields: 'results.id,results.photos.id,results.photos.license_code,results.photos.url,results.photos.medium_url,results.photos.large_url,results.photos.attribution,results.observed_on_details.date,results.taxon.id'
       };
 
       async function query(params) {
@@ -377,6 +377,8 @@
           if (good.length) {
             const photos = good.slice(0,4).map(p => ({
               url: p.url,
+              medium_url: p.medium_url,
+              large_url: p.large_url,
               attribution: p.attribution || 'iNaturalist contributor',
               license_code: p.license_code
             }));
@@ -523,7 +525,7 @@
 
       gameState.seenSpeciesThisGame.add(correct.scientific);
       gameState.newPhotosUsedThisQuestion = false;
-      newPhotosBtn.style.display = 'block'; newPhotosBtn.disabled = false; newPhotosBtn.textContent = 'New Photos (1 use)';
+      newPhotosBtn.style.display = 'inline-flex'; newPhotosBtn.disabled = false; newPhotosBtn.textContent = 'New Photos (1 use)';
 
       // Build options based on difficulty
       const options = [correct];
@@ -555,12 +557,16 @@
       gameState.currentQuestion = { correct, options, currentObservationId: data.observationId, observationUrl_DEBUG: data.observationUrl };
 
       // Render images (2x2)
-      imageGrid.innerHTML = data.photos.map(p => `
+      imageGrid.innerHTML = data.photos.map(p => {
+        const medium = p.medium_url || p.url.replace('/square.', '/medium.');
+        const large = p.large_url || p.url.replace('/square.', '/large.');
+        return `
         <div class="image-container">
-          <img src="${p.url}" class="mushroom-image" alt="Mushroom photo" onerror="handleImageError(this)">
+          <img src="${medium}" srcset="${large} 2x" class="mushroom-image" alt="Mushroom photo" onerror="handleImageError(this)">
           <div class="photo-credit">${p.attribution} <span class="license-badge">${(p.license_code || '').toUpperCase()}</span></div>
         </div>
-      `).join('');
+        `;
+      }).join('');
       const oldAttr = imageGrid.querySelector('.attribution'); if (oldAttr) oldAttr.remove();
       if (data.observationUrl) {
         const attr = document.createElement('div'); attr.className = 'attribution';
@@ -581,12 +587,16 @@
       const excludeId = gameState.currentQuestion.currentObservationId;
       const newData = await fetchMushroomObservation(gameState.currentQuestion.correct, excludeId);
       if (newData && !newData.error && !newData.skip && newData.photos?.length) {
-        imageGrid.innerHTML = newData.photos.map(p => `
+        imageGrid.innerHTML = newData.photos.map(p => {
+          const medium = p.medium_url || p.url.replace('/square.', '/medium.');
+          const large = p.large_url || p.url.replace('/square.', '/large.');
+          return `
           <div class="image-container">
-            <img src="${p.url}" class="mushroom-image" onerror="handleImageError(this)">
+            <img src="${medium}" srcset="${large} 2x" class="mushroom-image" onerror="handleImageError(this)">
             <div class="photo-credit">${p.attribution} <span class="license-badge">${(p.license_code || '').toUpperCase()}</span></div>
           </div>
-        `).join('');
+          `;
+        }).join('');
         const oldAttr = imageGrid.querySelector('.attribution'); if (oldAttr) oldAttr.remove();
         if (newData.observationUrl) {
           const attr = document.createElement('div'); attr.className = 'attribution';


### PR DESCRIPTION
## Summary
- Request medium and large photo URLs from API and prefer them with srcset for sharper images
- Center answer and photo grids with 2×2 square cards and limit width for a more compact layout
- Center the "New Photos" button using inline-flex styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a02ed66188329bb6e3455f0c47e16