### PR TITLE
Restore compact answer button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
     .secondary-action-button { background: #d4c8b8; color: #3d2914; border: 1px solid #bcaea0; padding: 10px 18px; border-radius: 999px; cursor: pointer; font-weight: 600; }
     .secondary-action-button:disabled { opacity: .55; cursor: not-allowed; }
 
-    .options { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; max-width: 740px; margin: 0 auto; }
-    .option-button { background: rgba(255, 248, 240, 0.85); border: 2px solid rgba(139, 90, 43, 0.25); color: #5d4e37; padding: 16px; border-radius: 12px; cursor: pointer; font-weight: 600; text-align: center; aspect-ratio: 1 / 1; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+    .options { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; max-width: 740px; margin: 0 auto; }
+    .option-button { background: rgba(255, 248, 240, 0.85); border: 2px solid rgba(139, 90, 43, 0.25); color: #5d4e37; padding: 16px; border-radius: 12px; cursor: pointer; font-weight: 600; text-align: center; display: flex; flex-direction: column; align-items: center; justify-content: center; }
     .option-button:hover:not(:disabled) { background: rgba(139, 90, 43, 0.15); border-color: rgba(139, 90, 43, 0.45); transform: translateY(-1px); }
     .option-button:disabled { opacity: .75; cursor: not-allowed; }
     .option-button.correct { background: rgba(76, 175, 80, 0.18); border-color: #4CAF50; color: #2e7d32; }


### PR DESCRIPTION
## Summary
- shrink answer buttons and restore a four-column grid so all answers fit on one row
- keep existing hover and correct/incorrect styles

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test_throttle.js` *(fails: dom.window.fetchMushroomObservations is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689b116f14f08329b3176c3558aafc2d